### PR TITLE
Implemented strict DI & separating controller logic

### DIFF
--- a/js/ang-accordion.js
+++ b/js/ang-accordion.js
@@ -4,89 +4,95 @@
  * Licensed under the MIT license
  */
 
-'use strict';
+(function() {
+    'use strict';
 
-angular.module('angAccordion', ['collapsibleItem']).directive('angAccordion', function() {
-  return {
-    restrict: 'EA',
-    transclude: true,
-    replace: true,
-    scope: {
-      oneAtATime: '@',
-      closeIconUrl: '@',
-      openIconUrl: '@',
-      closeIconClass: '@',
-      openIconClass: '@',
-      iconPosition: '@' 
-    },
-    controller: function($scope) {
-      var collapsibleItems = [];
-      
-      this.openCollapsibleItem = function(collapsibleItemToOpen) {
-        if( $scope.oneAtATime ) {
-          angular.forEach(collapsibleItems, function(collapsibleItem) {
-            collapsibleItem.isOpenned = false;
-            collapsibleItem.icon = collapsibleItem.closeIcon;
-          });
-        }
-        collapsibleItemToOpen.isOpenned = true;
+    angular
+      .module('angAccordion', ['collapsibleItem'])
+      .controller('angAccordionController', ['$scope', function($scope){
+        var collapsibleItems = [];
+          
+          this.openCollapsibleItem = function(collapsibleItemToOpen) {
+            if( $scope.oneAtATime ) {
+              angular.forEach(collapsibleItems, function(collapsibleItem) {
+                collapsibleItem.isOpenned = false;
+                collapsibleItem.icon = collapsibleItem.closeIcon;
+              });
+            }
+            collapsibleItemToOpen.isOpenned = true;
+          };
+
+          this.addCollapsibleItem = function(collapsibleItem) {
+            collapsibleItems.push(collapsibleItem);
+            
+            if ( $scope.closeIconClass !== undefined || $scope.openIconClass !== undefined ) {
+              collapsibleItem.iconsType = 'class';
+              collapsibleItem.closeIcon = $scope.closeIconClass;
+              collapsibleItem.openIcon = $scope.openIconClass;
+            }
+            else if ( $scope.closeIconUrl !== undefined || $scope.openIconUrl !== undefined ) {
+              collapsibleItem.iconsType = 'url';
+              collapsibleItem.closeIcon = $scope.closeIconUrl;
+              collapsibleItem.openIcon = $scope.openIconUrl;
+            }
+
+            collapsibleItem.iconIsOnLeft = $scope.iconPosition == 'left' ? true: false;
+          };
+
+      }])
+      .directive('angAccordion', function() {
+      return {
+        restrict: 'EA',
+        transclude: true,
+        replace: true,
+        scope: {
+          oneAtATime: '@',
+          closeIconUrl: '@',
+          openIconUrl: '@',
+          closeIconClass: '@',
+          openIconClass: '@',
+          iconPosition: '@' 
+        },
+        controller: 'angAccordionController',
+        template: '<div class="accordion" ng-transclude></div>'
       };
+    });
 
-      this.addCollapsibleItem = function(collapsibleItem) {
-        collapsibleItems.push(collapsibleItem);
-        
-        if ( $scope.closeIconClass != undefined || $scope.openIconClass != undefined ) {
-          collapsibleItem.iconsType = 'class';
-          collapsibleItem.closeIcon = $scope.closeIconClass;
-          collapsibleItem.openIcon = $scope.openIconClass;
-        }
-        else if ( $scope.closeIconUrl != undefined || $scope.openIconUrl != undefined ) {
-          collapsibleItem.iconsType = 'url';
-          collapsibleItem.closeIcon = $scope.closeIconUrl;
-          collapsibleItem.openIcon = $scope.openIconUrl;
-        }
+    angular.module('collapsibleItem', []).directive('collapsibleItem', function() {
+      return {
+        require: '^angAccordion',
+        restrict: 'EA',
+        transclude: true,
+        replace: true,
+        scope: {
+          title: '@',
+          initiallyOpen: '@'
+        },
+        link: function(scope, element, attrs, accordionController) {
+          scope.isOpenned = (scope.initiallyOpen) ? true : false;
+          accordionController.addCollapsibleItem(scope);
+          
+          if(scope.isOpenned)
+            scope.icon = scope.openIcon;
+          else
+            scope.icon = scope.closeIcon;
 
-        collapsibleItem.iconIsOnLeft = $scope.iconPosition == 'left' ? true: false;
+          scope.toggleCollapsibleItem = function () {
+            if(!scope.isOpenned) {
+              accordionController.openCollapsibleItem(this);
+              scope.icon = scope.openIcon;
+            }
+            else {
+              scope.isOpenned = false;
+              scope.icon = scope.closeIcon;
+            }
+          };
+
+          scope.getIconUrl = function ( type ) {
+            return type == 'url' ? scope.icon : null;
+          };
+        },
+        template: '<div class="collapsible-item" ng-class="{open: isOpenned}"><div class="title" ng-click="toggleCollapsibleItem()">{{title}}<i ng-show="iconsType == \'class\'" class="{{icon}} icon" ng-class="{iconleft: iconIsOnLeft}"></i><img ng-show="iconsType == \'url\'" class="icon" ng-class="{iconleft: iconIsOnLeft}" ng-src="{{getIconUrl(iconsType)}}" /></div><div class="body"><div class="content" ng-transclude></div></div></div>'
       };
-    },
-    template: '<div class="accordion" ng-transclude></div>'
-  };
-});
-
-angular.module('collapsibleItem', []).directive('collapsibleItem', function() {
-  return {
-    require: '^angAccordion',
-    restrict: 'EA',
-    transclude: true,
-    replace: true,
-    scope: {
-      title: '@',
-      initiallyOpen: '@'
-    },
-    link: function(scope, element, attrs, accordionController) {
-      scope.isOpenned = (scope.initiallyOpen) ? true : false;
-      accordionController.addCollapsibleItem(scope);
-      
-      if(scope.isOpenned)
-        scope.icon = scope.openIcon;
-      else
-        scope.icon = scope.closeIcon;
-
-      scope.toggleCollapsibleItem = function () {
-        if(!scope.isOpenned) {
-          accordionController.openCollapsibleItem(this);
-          scope.icon = scope.openIcon;
-        }
-        else {
-          scope.isOpenned = false;
-          scope.icon = scope.closeIcon;
-        }
-      };
-
-      scope.getIconUrl = function ( type ) {
-        return type == 'url' ? scope.icon : null;
-      }
-    },
-    template: '<div class="collapsible-item" ng-class="{open: isOpenned}"><div class="title" ng-click="toggleCollapsibleItem()">{{title}}<i ng-show="iconsType == \'class\'" class="{{icon}} icon" ng-class="{iconleft: iconIsOnLeft}"></i><img ng-show="iconsType == \'url\'" class="icon" ng-class="{iconleft: iconIsOnLeft}" ng-src="{{getIconUrl(iconsType)}}" /></div><div class="body"><div class="content" ng-transclude></div></div></div>'
-  };
-});
+    });
+})();


### PR DESCRIPTION
The original directive would have failed in cases of strict DI (dependency injection) or minification. It failed for me while using it on a Firefox OS Flame 2.0 device, while it  worked on simulator. Even with minification, (with implicit DI) it would replace the "$scope" function argument with some variable like "b". This would fail inside the controller logic since it would expect $scope, but gets "b".

Refactored the main script file to do two things:
- Implemented changes to have explicit annotation for supporting strict DI (minification would work).
- Separate out controller logic from the directive. This keeps the directive free of any business logic.

With this, now the directive can be used under strict DI scenarios as well as minification. Please check.

Awesome widget btw! Thanx!