### PR TITLE
Added html support for title

### DIFF
--- a/js/ang-accordion.js
+++ b/js/ang-accordion.js
@@ -66,6 +66,7 @@
         replace: true,
         scope: {
           title: '@',
+          htmlTitle: '@',
           initiallyOpen: '@'
         },
         link: function(scope, element, attrs, accordionController) {
@@ -92,7 +93,7 @@
             return type == 'url' ? scope.icon : null;
           };
         },
-        template: '<div class="collapsible-item" ng-class="{open: isOpenned}"><div class="title" ng-click="toggleCollapsibleItem()">{{title}}<i ng-show="iconsType == \'class\'" class="{{icon}} icon" ng-class="{iconleft: iconIsOnLeft}"></i><img ng-show="iconsType == \'url\'" class="icon" ng-class="{iconleft: iconIsOnLeft}" ng-src="{{getIconUrl(iconsType)}}" /></div><div class="body"><div class="content" ng-transclude></div></div></div>'
+        template:  '<div class="collapsible-item" ng-class="{open: isOpenned}"><div class="title" ng-click="toggleCollapsibleItem()" ng-show="!htmlTitle">{{title}} <i ng-show="iconsType == \'class\'" class="{{icon}} icon" ng-class="{iconleft: iconIsOnLeft}"></i><img ng-show="iconsType == \'url\'" class="icon" ng-class="{iconleft: iconIsOnLeft}" ng-src="{{getIconUrl(iconsType)}}" /></div><div class="title" ng-click="toggleCollapsibleItem()" ng-show="htmlTitle" ng-bind-html="title"></div><div class="body"><div class="content" ng-transclude></div></div></div>'
       };
     });
 })();


### PR DESCRIPTION
We have a requirement to be able to put extra data in our title area of accordions, I have added the 'html-title' attribute, that when set to true show's a title with ng-bind-html set on the title div rather than all of the icon options and the plain text.